### PR TITLE
Add moderator user management screens & VMs

### DIFF
--- a/app/src/main/java/com/servicerca/app/core/navigation/DashboardRoutes.kt
+++ b/app/src/main/java/com/servicerca/app/core/navigation/DashboardRoutes.kt
@@ -35,8 +35,8 @@ sealed class DashboardRoutes {
     @Serializable
     data object Historial : DashboardRoutes()
 
-
-
+    @Serializable
+    data object ManageUser : DashboardRoutes()
 
 }
 

--- a/app/src/main/java/com/servicerca/app/core/navigation/UserNavigation.kt
+++ b/app/src/main/java/com/servicerca/app/core/navigation/UserNavigation.kt
@@ -11,11 +11,7 @@ import androidx.navigation.toRoute
 import com.servicerca.app.ui.chat.ChatListScreen
 import com.servicerca.app.ui.chat.ChatScreen
 import com.servicerca.app.ui.dashboard.user.HomeUserScreen
-<<<<<<< Updated upstream
-=======
-import com.servicerca.app.ui.dashboard.moderador.ModeratorPanelScreen
 import com.servicerca.app.ui.dashboard.moderador.userProfile.ManageUserScreen
->>>>>>> Stashed changes
 import com.servicerca.app.ui.profile.DeleteProfileScreen
 import com.servicerca.app.ui.profile.EditProfileScreen
 import com.servicerca.app.ui.profile.InsigniasScreen

--- a/app/src/main/java/com/servicerca/app/core/navigation/UserNavigation.kt
+++ b/app/src/main/java/com/servicerca/app/core/navigation/UserNavigation.kt
@@ -11,6 +11,11 @@ import androidx.navigation.toRoute
 import com.servicerca.app.ui.chat.ChatListScreen
 import com.servicerca.app.ui.chat.ChatScreen
 import com.servicerca.app.ui.dashboard.user.HomeUserScreen
+<<<<<<< Updated upstream
+=======
+import com.servicerca.app.ui.dashboard.moderador.ModeratorPanelScreen
+import com.servicerca.app.ui.dashboard.moderador.userProfile.ManageUserScreen
+>>>>>>> Stashed changes
 import com.servicerca.app.ui.profile.DeleteProfileScreen
 import com.servicerca.app.ui.profile.EditProfileScreen
 import com.servicerca.app.ui.profile.InsigniasScreen
@@ -210,6 +215,17 @@ fun UserNavigation(
         composable("Chat/{chatId}") {
             ChatScreen(onBack = { navController.popBackStack()})
         }
+
+
+        composable<DashboardRoutes.ManageUser> {
+            ManageUserScreen(
+                onSeeProfile = {
+                    navController.navigate("userDetail/{userId}")
+                }
+            )
+        }
+
+
 
 
 

--- a/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/ManageUserScreen.kt
+++ b/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/ManageUserScreen.kt
@@ -1,4 +1,4 @@
-package com.servicerca.app.ui.dashboard.moderador
+package com.servicerca.app.ui.dashboard.moderador.userProfile
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,14 +8,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.servicerca.app.R
 import com.servicerca.app.core.components.card.CardProfileManage
 import com.servicerca.app.core.components.card.CardStatisticsUserManage
@@ -23,7 +26,14 @@ import com.servicerca.app.core.components.input.SearchTextField
 import com.servicerca.app.core.components.navigation.ScrollPage
 
 @Composable
-fun ManageUserScreen(){
+fun ManageUserScreen(
+    viewModel: ManageUserViewModel = hiltViewModel(),
+    onSeeProfile: (String) -> Unit = {},
+    onSuspendProfile: (String) -> Unit = {},
+    onDeleteProfile: (String) -> Unit = {}
+) {
+    val users by viewModel.users.collectAsState()
+    val searchQuery by viewModel.searchQuery.collectAsState()
 
     Column(
         modifier = Modifier
@@ -32,16 +42,15 @@ fun ManageUserScreen(){
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         SearchTextField(
-            query = "",
-            onQueryChange = {},
+            query = searchQuery,
+            onQueryChange = viewModel::onSearchQueryChange,
             placeholder = stringResource(R.string.label_search_user)
         )
 
-        Spacer(modifier = Modifier.height(16.dp)) // Espacio para el filtro
+        Spacer(modifier = Modifier.height(16.dp))
 
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
         ) {
             Row(
                 modifier = Modifier
@@ -50,29 +59,27 @@ fun ManageUserScreen(){
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 CardStatisticsUserManage(
-                    number = "12952",
+                    number = users.size.toString(),
                     label = stringResource(R.string.label_count_all_users)
                 )
 
                 CardStatisticsUserManage(
-                    number = "+69",
+                    number = "+0", // Placeholder
                     label = stringResource(R.string.label_count_new_users)
                 )
             }
 
             Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
-
             ) {
                 CardStatisticsUserManage(
-                    number = "1204",
+                    number = users.size.toString(), // Placeholder
                     label = stringResource(R.string.label_count_active_users)
                 )
 
                 CardStatisticsUserManage(
-                    number = "29",
+                    number = "0", // Placeholder
                     label = stringResource(R.string.label_count_pending_users)
                 )
             }
@@ -80,56 +87,32 @@ fun ManageUserScreen(){
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .padding(8.dp)
-                .weight(1f)
-                .verticalScroll(rememberScrollState()),
+                .weight(1f),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            CardProfileManage(
-                name = stringResource(R.string.username_manage_user1),
-                email = stringResource(R.string.email_manage_user1),
-                imageProfile = R.drawable.foto_perfil
-            )
-
-            CardProfileManage(
-                name = stringResource(R.string.username_manage_user2),
-                email = stringResource(R.string.email_manage_user2),
-                imageProfile = R.drawable.foto_perfil
-            )
-
-            CardProfileManage(
-                name = stringResource(R.string.username_manage_user3),
-                email = stringResource(R.string.email_manage_user3),
-                imageProfile = R.drawable.foto_perfil
-            )
-
-            CardProfileManage(
-                name = stringResource(R.string.username_manage_user4),
-                email = stringResource(R.string.email_manage_user4),
-                imageProfile = R.drawable.foto_perfil
-            )
-
-
+            items(users) { user ->
+                CardProfileManage(
+                    name = "${user.name1} ${user.lastname1}",
+                    email = user.email,
+                    imageProfile = R.drawable.foto_perfil, // Debería cargarse desde URL si CardProfileManage lo soporta
+                    onSeeProfile = { onSeeProfile(user.id) }
+                )
+            }
         }
 
         ScrollPage(
             currentPage = 1,
-            totalPages = 5,
+            totalPages = 1,
             onPageChange = {}
         )
-
-
-
-
-
-
     }
 }
 
 @Composable
 @Preview(showBackground = true)
-fun ManageUserScreenPreview(){
+fun ManageUserScreenPreview() {
     ManageUserScreen()
 }

--- a/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/ManageUserViewModel.kt
+++ b/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/ManageUserViewModel.kt
@@ -1,0 +1,44 @@
+package com.servicerca.app.ui.dashboard.moderador.userProfile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.servicerca.app.domain.model.User
+import com.servicerca.app.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ManageUserViewModel @Inject constructor(
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    val users: StateFlow<List<User>> = userRepository.users
+        .combine(_searchQuery) { users, query ->
+            if (query.isBlank()) {
+                users
+            } else {
+                users.filter { user ->
+                    user.name1.contains(query, ignoreCase = true) ||
+                            user.lastname1.contains(query, ignoreCase = true) ||
+                            user.email.contains(query, ignoreCase = true)
+                }
+            }
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+    }
+}

--- a/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/UserProfileManage.kt
+++ b/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/UserProfileManage.kt
@@ -1,0 +1,76 @@
+package com.servicerca.app.ui.dashboard.moderador.userProfile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.servicerca.app.R
+import com.servicerca.app.core.components.card.CardLevel
+import com.servicerca.app.core.components.images.ProfileImage
+import com.servicerca.app.ui.profile.StatisticsSection
+
+@Composable
+fun UserProfileManage(
+    viewModel: UserProfileManageViewModel = hiltViewModel()
+) {
+    val user by viewModel.user.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        // Imagen de Perfil
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Box(modifier = Modifier.size(150.dp)) {
+                ProfileImage(url = user?.profilePictureUrl ?: "")
+            }
+        }
+
+        // Nombre del Usuario
+        Text(
+            text = user?.let { "${it.name1} ${it.lastname1}" } ?: stringResource(R.string.profile_fallback_name),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+
+        CardLevel()
+
+
+        StatisticsSection(
+            user = user
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun UserProfileManagePreview() {
+    UserProfileManage()
+}

--- a/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/UserProfileManageViewModel.kt
+++ b/app/src/main/java/com/servicerca/app/ui/dashboard/moderador/userProfile/UserProfileManageViewModel.kt
@@ -1,0 +1,29 @@
+package com.servicerca.app.ui.dashboard.moderador.userProfile
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.servicerca.app.domain.model.User
+import com.servicerca.app.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class UserProfileManageViewModel @Inject constructor(
+    private val repository: UserRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val userId: String? = savedStateHandle["userId"]
+
+    private val _user = MutableStateFlow<User?>(null)
+    val user: StateFlow<User?> = _user.asStateFlow()
+
+    init {
+        userId?.let { id ->
+            _user.value = repository.findById(id)
+        }
+    }
+}


### PR DESCRIPTION
Introduce moderator user management features: add a ManageUser route and navigation composable, rename/refactor ManageUserScreen into a userProfile package, and connect it to a new ManageUserViewModel (Hilt) that exposes searchable user StateFlow. Replace static list and verticalScroll with a LazyColumn that renders repository-backed users and wire searchQuery handling. Also add UserProfileManage screen and UserProfileManageViewModel to display individual user details fetched by id. Minor UI adjustments: dynamic counts for stats (placeholders where appropriate), pagination stub, and package/import updates.